### PR TITLE
remove: web3-bot from nebula-analyis

### DIFF
--- a/github/plprobelab.yml
+++ b/github/plprobelab.yml
@@ -174,9 +174,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - web3-bot
     default_branch: main
     has_discussions: false
     merge_commit_message: PR_TITLE


### PR DESCRIPTION
### Summary
removes the web3-bot from the nebula-analysis repo. We're not using Go or JS there, so it makes no sense to have it there.