### PR TITLE
add ipdx to github-mgmt admin

### DIFF
--- a/github/probe-lab.yml
+++ b/github/probe-lab.yml
@@ -9,10 +9,10 @@ members:
     - iand
     - yiannisbot
   member:
+    - galargh
+    - laurentsenta
     - probelab-cmi
     - web3-bot
-    - laurentsenta
-    - galargh
 repositories:
   .github:
     advanced_security: false
@@ -326,8 +326,8 @@ teams:
   ipdx:
     members:
       member:
-        - laurentsenta
         - galargh
+        - laurentsenta
   probelab-bots:
     members:
       member:

--- a/github/probe-lab.yml
+++ b/github/probe-lab.yml
@@ -11,6 +11,8 @@ members:
   member:
     - probelab-cmi
     - web3-bot
+    - laurentsenta
+    - galargh
 repositories:
   .github:
     advanced_security: false
@@ -92,6 +94,9 @@ repositories:
     secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - ipdx
   go-kademlia:
     advanced_security: false
     allow_update_branch: false
@@ -318,6 +323,11 @@ repositories:
       - kademlia
       - libp2p
 teams:
+  ipdx:
+    members:
+      member:
+        - laurentsenta
+        - galargh
   probelab-bots:
     members:
       member:


### PR DESCRIPTION
### Summary
Add www.ipdx.co team as github-mgmt admin

### Why do you need this?
In order to upgrade and maintain this repo, we need admin access to configure it.

### Reviewer's Checklist
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
