### PR TITLE
add achingbrain to read the probelab-infra repo cc: @SgtPooki

### DIFF
--- a/github/probe-lab.yml
+++ b/github/probe-lab.yml
@@ -215,8 +215,8 @@ repositories:
       maintain:
         - BigLep
       pull:
-        - whizzzkid
         - achingbrain
+        - whizzzkid
       push:
         - kasteph
         - lidel

--- a/github/probe-lab.yml
+++ b/github/probe-lab.yml
@@ -216,6 +216,7 @@ repositories:
         - BigLep
       pull:
         - whizzzkid
+        - achingbrain
       push:
         - kasteph
         - lidel


### PR DESCRIPTION
### Summary
Grant @achingbrain reading permissions to the `probelab-infra` repo.

### Why do you need this?
As suggested by Russell (@SgtPooki), @achingbrain should have at least reading access to the infra repo to see how is the Helia monitoring set up.

### What else do we need to know?

**DRI:** @cortze 

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
